### PR TITLE
chore: wait for SQLServer in CI

### DIFF
--- a/.github/workflows/cargo-test.yaml
+++ b/.github/workflows/cargo-test.yaml
@@ -29,6 +29,7 @@ jobs:
       - uses: isbang/compose-action@v1.5.1
         with:
           compose-file: "./docker-compose.yaml"
+          up-flags: "--pull=always --wait"
           down-flags: "--volumes"
           services: |
             sqlserver


### PR DESCRIPTION
<!-- The PR description should answer 2 (maybe 3) important questions: -->

### What

Do `docker-compose up --wait` in CI.

### How

<!-- How is it trying to accomplish it (what are the implementation steps)? -->
