### PR TITLE
Don't use PR branch of ndc-sdk-rs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1260,7 +1260,7 @@ dependencies = [
 [[package]]
 name = "ndc-sdk"
 version = "0.1.0"
-source = "git+https://github.com/hasura/ndc-sdk-rs.git?rev=fe945b6616e5b8bbefa537e5044b4ec962416d4b#fe945b6616e5b8bbefa537e5044b4ec962416d4b"
+source = "git+https://github.com/hasura/ndc-sdk-rs.git?rev=a273a01efccfc71ef3341cf5f357b2c9ae2d109f#a273a01efccfc71ef3341cf5f357b2c9ae2d109f"
 dependencies = [
  "async-trait",
  "axum",
@@ -1924,7 +1924,6 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "rustls 0.21.10",
- "rustls-native-certs 0.6.3",
  "rustls-pemfile 1.0.4",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,6 @@ unused_async = "allow"
 [workspace.dependencies]
 # ndc-models was using version 0.1.2 but we needed rustls fix
 ndc-models = { git = "https://github.com/hasura/ndc-spec.git", rev = "c59f824ff95e6a376c34f85816e80164bc1f3894" }
-ndc-sdk = { git = "https://github.com/hasura/ndc-sdk-rs.git", rev = "7409334d2ec2ca1d05fb341e69c9f07af520d8e0",  default-features = false, features = ["rustls"]}
+ndc-sdk = { git = "https://github.com/hasura/ndc-sdk-rs.git", rev = "a273a01efccfc71ef3341cf5f357b2c9ae2d109f",  default-features = false, features = ["rustls"]}
 # ndc-test was using version 0.1.2 but we needed rustls fix
 ndc-test = { git = "https://github.com/hasura/ndc-spec.git", rev = "c59f824ff95e6a376c34f85816e80164bc1f3894", default-features = false, features = ["rustls"] }


### PR DESCRIPTION
<!-- The PR description should answer 2 (maybe 3) important questions: -->

### What

When trying to get the Linux aarch64 build working we moved to using a `ndc-sdk-rs` commit from a PR,but have closed that PR now. 

### How

Reverting this to refer to a merged commit on `ndc-sdk-rs` instead.

