### PR TITLE
Update docker.nix file to add cmd and healthcheck

### DIFF
--- a/nix/docker.nix
+++ b/nix/docker.nix
@@ -9,6 +9,7 @@
 }:
 
 let
+  seconds = 1000 * 1000 * 1000; # nanoseconds in 1 second
   args = {
     name = image-name;
     created = "now";
@@ -17,10 +18,24 @@ let
       Entrypoint = [
         "/bin/${package.pname}"
       ];
+      Cmd = [
+        "serve"
+      ];
       Env = [
         ''HASURA_CONFIGURATION_DIRECTORY=/etc/connector''
       ];
       ExposedPorts = { "8080/tcp" = { }; };
+      Healthcheck = {
+        Test = [
+          "CMD"
+          "/bin/${package.pname}"
+          "check-health"
+        ];
+        StartInterval = 1 * seconds;
+        Interval = 5 * seconds;
+        Timeout = 10 * seconds;
+        Retries = 3;
+      };
     } // extraConfig;
   }
   // lib.optionalAttrs (tag != null) {


### PR DESCRIPTION
This PR updates the docker.nix file to add the cmd and healthcheck. This is now the same as the postgres docker.nix file.