### PR TITLE
Update docs to reflect ADO.NET connection string

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,11 @@
 [![ndc-hub](https://img.shields.io/badge/ndc--hub-sqlserver-blue.svg?style=flat)](https://hasura.io/connectors/sqlserver)
 [![License](https://img.shields.io/badge/license-Apache--2.0-purple.svg?style=flat)](LICENSE.txt)
 
+> **Note:** ADO.NET is the supported connection string format for SQL Server for ndc-sqlserver in DDN. 
+> You can find the documentation for ADO.NET SQL Server connection strings [here](https://learn.microsoft.com/en-us/dotnet/framework/data/adonet/connection-string-syntax#sqlclient-connection-strings).
+> This is a change from Hasura version 2, where ODBC connection strings were supported.
+
+
 With this connector, Hasura allows you to instantly create a real-time GraphQL API on top of your data models in
 Microsoft SQL Server. This connector supports SQL Server's functionalities listed in the table below, allowing for
 efficient and scalable data operations. Additionally, users benefit from all the powerful features of Hasura’s Data
@@ -76,6 +81,8 @@ The CLI will ask for a specific port to run the connector on. Choose a port that
 default suggested port.
 
 #### Step 2.3: Provide the env vars for the connector
+
+> **Note:** The `CONNECTION_URI` is the connection string of the SQL Server database. You can find the documentation for ADO.NET SQL Server connection string formats [here](https://learn.microsoft.com/en-us/dotnet/framework/data/adonet/connection-string-syntax#sqlclient-connection-strings).
 
 | Name           | Description                                      | Required | Default |
 |----------------|--------------------------------------------------|----------|---------|

--- a/crates/configuration/src/version1.rs
+++ b/crates/configuration/src/version1.rs
@@ -144,13 +144,26 @@ pub async fn create_state(
     })
 }
 
+// If the connection string is ODBC we want to throw an error.
+fn is_odbc_connection_string(conn_str: &str) -> Result<(), bb8_tiberius::Error> {
+    if conn_str.contains("Driver=") || conn_str.contains("DSN=") {
+        Err(bb8_tiberius::Error::Tiberius(tiberius::error::Error::Io {
+            kind: std::io::ErrorKind::Other,
+            message: "ODBC connection strings are not supported. ADO.NET is the supported format.".into(),
+        }))
+    } else {
+        Ok(())
+    }
+}
+
 /// Create a connection pool with default settings.
 async fn create_mssql_pool(
     configuration: &str,
 ) -> Result<bb8::Pool<bb8_tiberius::ConnectionManager>, bb8_tiberius::Error> {
     let connection_string = configuration.to_owned();
+    // Lets check the string and error early if it is an ODBC connection string
+    is_odbc_connection_string(&connection_string)?;
     let config = tiberius::Config::from_ado_string(&connection_string)?;
-
     let mgr = bb8_tiberius::ConnectionManager::new(config);
 
     bb8::Pool::builder().max_size(2).build(mgr).await

--- a/crates/configuration/src/version1.rs
+++ b/crates/configuration/src/version1.rs
@@ -149,7 +149,8 @@ fn is_odbc_connection_string(conn_str: &str) -> Result<(), bb8_tiberius::Error> 
     if conn_str.contains("Driver=") || conn_str.contains("DSN=") {
         Err(bb8_tiberius::Error::Tiberius(tiberius::error::Error::Io {
             kind: std::io::ErrorKind::Other,
-            message: "ODBC connection strings are not supported. ADO.NET is the supported format.".into(),
+            message: "ODBC connection strings are not supported. ADO.NET is the supported format."
+                .into(),
         }))
     } else {
         Ok(())


### PR DESCRIPTION
<!-- The PR description should answer 2 (maybe 3) important questions: -->

### What
In Hasura v2 we supported ODBC connection string for sqlserver, but in DDN we support ADO.NET connection strings.

<!-- What is this PR trying to accomplish (and why, if it's not obvious)? -->

### How
- Update docs to reflect the connection string format supported
- Try to detect ODBC format and throw a useful error when initializing the connection

<!-- How is it trying to accomplish it (what are the implementation steps)? -->
